### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build](https://github.com/cgs-earth/sensorthings-action/actions/workflows/main.yml/badge.svg)](https://github.com/cgs-earth/sensorthings-action/actions/workflows/main.yml)
 
 This action runs a SensorThings API services using the [FROST-Server](https://github.com/FraunhoferIOSB/FROST-Server).
-This is not meant to be used for unit testing only.
+This is meant to be used for unit testing only.
 
 ## Inputs
 


### PR DESCRIPTION
I believe this is a typo. This sensorthings-action is _only_ for unit testing it appears. All of the tests in `test_sensorthings.py` are unit tests. If not, perhaps the wording could be changed to make it more clear.