### PR TITLE
Add push-postgis job to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -64,3 +64,49 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  push-postgis:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REGISTRY }}/sensorthings-postgis
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: ./postgis
+          file: ./postgis/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/arm64, linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,11 @@ on: [ push ]
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - python-version: '3.10'
+          - python-version: '3.12'
 
     steps:
     - uses: actions/checkout@v2

--- a/action.yml
+++ b/action.yml
@@ -48,16 +48,21 @@ inputs:
     description: 'database password'
     required: true
     default: 'ChangeMe'
-outputs:
-  sta:
-    description: 'sensorthings server'
 runs:
   using: "composite"
   steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v4
+      with:
+        path: sta
+        sparse-checkout: |
+          .
+          postgis
     - shell: bash
+      env:
+        POSTGRES_TABLE: ${{ inputs.table }}
+        POSTGRES_USER: ${{ inputs.username }}
+        POSTGRES_PASS: ${{ inputs.password }}
       run: |
-        docker run \
-         -v /var/run/docker.sock:/var/run/docker.sock \
-         ghcr.io/cgs-earth/sensorthings-action:0.1.0 \
-         up \
-         ${{ inputs.table }} ${{ inputs.username }} ${{ inputs.password }}
+        cd sta
+        docker compose up -d

--- a/test_sensorthings.py
+++ b/test_sensorthings.py
@@ -70,7 +70,7 @@ def test_query_datastreams(config):
     assert len(results['features']) == 1
     assert results['features'][0]['id'] == '3'
 
-    assert len(results['features'][0]['properties']) == 18
+    assert len(results['features'][0]['properties']) == 19
 
     results = p.query(bbox=[-109, 36, -106, 37])
     assert results['numberReturned'] == 8


### PR DESCRIPTION
Added a new job 'push-postgis' to build and push Docker images to GitHub Container Registry with appropriate permissions and steps.